### PR TITLE
Modified that cache item ttl can be changed from the outside

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>

--- a/src/main/java/com/amazonaws/secretsmanager/caching/SecretCacheConfiguration.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/SecretCacheConfiguration.java
@@ -33,6 +33,12 @@ public class SecretCacheConfiguration {
     /** The default version stage to use when retrieving secret values. */
     public static final String DEFAULT_VERSION_STAGE = "AWSCURRENT";
 
+    /** The environment variable name of cache item ttl. */
+    public static final String CACHE_ITEM_TTL_ENV = "AWS_SECRETSMANAGER_CACHE_ITEM_TTL";
+
+    /** The system property name of cache item ttl. */
+    public static final String CACHE_ITEM_TTL_PROP = "aws.secretsmanager.cache.item.ttl";
+
     /** The client this cache instance will use for accessing AWS Secrets Manager. */
     private AWSSecretsManager client = null;
 
@@ -64,6 +70,7 @@ public class SecretCacheConfiguration {
      *
      */
     public SecretCacheConfiguration() {
+        initialize();
     }
 
     /**
@@ -230,6 +237,32 @@ public class SecretCacheConfiguration {
     public SecretCacheConfiguration withVersionStage(String versionStage) {
         this.setVersionStage(versionStage);
         return this;
+    }
+
+    /**
+     * Sets the TTL in milliseconds for the cached items with environment variables
+     * or system properties, if not set variables use default cache item ttl.
+     */
+    private void initialize() {
+        cacheItemTTL = findCacheItemTTL();
+    }
+
+    private long findCacheItemTTL() {
+        String env = getCacheItemTTLEnv();
+        if (env != null) {
+             return Long.parseLong(env);
+        }
+
+        String prop = System.getProperties().getProperty(CACHE_ITEM_TTL_PROP);
+        if (prop != null) {
+            return Long.parseLong(prop);
+        }
+
+        return DEFAULT_CACHE_ITEM_TTL;
+    }
+
+    private String getCacheItemTTLEnv() {
+        return System.getenv(CACHE_ITEM_TTL_ENV);
     }
 
 }

--- a/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheConfigurationTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheConfigurationTest.java
@@ -1,0 +1,57 @@
+package com.amazonaws.secretsmanager.caching;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.testng.Assert;
+import org.testng.IObjectFactory;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * SecretCacheConfigurationTest
+ */
+public class SecretCacheConfigurationTest {
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+
+    @Test
+    public void findCacheItemTTLByDefaultTest() {
+        // Call default constructor
+        SecretCacheConfiguration secretCacheConfiguration = new SecretCacheConfiguration();
+
+        // Verify that cacheItemTTL set the default
+        Assert.assertEquals(secretCacheConfiguration.getCacheItemTTL(),
+                SecretCacheConfiguration.DEFAULT_CACHE_ITEM_TTL);
+    }
+
+    @Test
+    public void findCacheItemTTLEnvTest() throws Exception {
+        // Provisioning for test
+        SecretCacheConfiguration spy = PowerMockito.spy(new SecretCacheConfiguration());
+        PowerMockito.whenNew(SecretCacheConfiguration.class).withNoArguments()
+                .thenReturn(spy);
+        PowerMockito.doReturn(TimeUnit.HOURS.toMillis(12)).when(spy, "getCacheItemTTL");
+
+        // Verify that cacheItemTTL set from the system property
+        Assert.assertEquals(spy.getCacheItemTTL(),
+                TimeUnit.HOURS.toMillis(12));
+    }
+
+    @Test
+    public void findCacheItemTTLPropertyTest() {
+        // Provisioning for test
+        System.setProperty(SecretCacheConfiguration.CACHE_ITEM_TTL_PROP,
+                String.valueOf(TimeUnit.HOURS.toMillis(24)));
+
+        // Call default constructor
+        SecretCacheConfiguration secretCacheConfiguration = new SecretCacheConfiguration();
+
+        // Verify that cacheItemTTL set from the environment variable
+        Assert.assertEquals(secretCacheConfiguration.getCacheItemTTL(),
+                TimeUnit.HOURS.toMillis(24));
+    }
+}


### PR DESCRIPTION
*Issue #14:*

*Description of changes:*
- Add intialize method to SecretCacheConfiguration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
