### PR TITLE
feat: get secrets by `versionId` or `versionStage` (#19)

### DIFF
--- a/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
@@ -140,8 +140,8 @@ public class SecretCache implements AutoCloseable {
      * Retrieve and cache a secret string from AWS Secrets Manager.
      *
      * @param secretId the secret ID of the desired secret.
-     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
-     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     * @param versionId the version ID of the desired secret (optional, can be null).
+     * @param versionStage the version stage of the desired secret (optional, can be null).
      *
      * @return The secret string for the desired secret.
      */
@@ -175,8 +175,8 @@ public class SecretCache implements AutoCloseable {
      * Retrieve and cache a secret binary from AWS Secrets Manager.
      *
      * @param secretId the secret ID of the desired secret.
-     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
-     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     * @param versionId the version ID of the desired secret (optional, can be null).
+     * @param versionStage the version stage of the desired secret (optional, can be null).
      *
      * @return The secret binary for the desired secret.
      */

--- a/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
@@ -128,12 +128,7 @@ public class SecretCache implements AutoCloseable {
      * @return The string secret
      */
     public String getSecretString(final String secretId) {
-        SecretCacheItem secret = this.getCachedSecret(secretId);
-        GetSecretValueResponse gsv = secret.getSecretValue();
-        if (null == gsv) {
-            return null;
-        }
-        return gsv.secretString();
+        return getSecretString(secretId, null, null);
     }
 
     /**
@@ -163,12 +158,7 @@ public class SecretCache implements AutoCloseable {
      * @return The binary secret
      */
     public ByteBuffer getSecretBinary(final String secretId) {
-        SecretCacheItem secret = this.getCachedSecret(secretId);
-        GetSecretValueResponse gsv = secret.getSecretValue();
-        if (null == gsv) {
-            return null;
-        }
-        return gsv.secretBinary().asByteBuffer();
+        return getSecretBinary(secretId, null, null);
     }
 
     /**

--- a/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
@@ -137,6 +137,26 @@ public class SecretCache implements AutoCloseable {
     }
 
     /**
+     * Retrieve and cache a secret string from AWS Secrets Manager.
+     *
+     * @param secretId the secret ID of the desired secret.
+     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
+     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     *
+     * @return The secret string for the desired secret.
+     */
+    public String getSecretString(final String secretId, final String versionId, final String versionStage) {
+        SecretCacheItem secret = this.getCachedSecret(secretId);
+        GetSecretValueResponse gsv = secret.getSecretValue(versionId, versionStage);
+
+        if (gsv == null) {
+            return null;
+        }
+
+        return gsv.secretString();
+    }
+
+    /**
      * Method to retrieve a binary secret from AWS Secrets Manager.
      *
      * @param secretId The identifier for the secret being requested.
@@ -148,6 +168,26 @@ public class SecretCache implements AutoCloseable {
         if (null == gsv) {
             return null;
         }
+        return gsv.secretBinary().asByteBuffer();
+    }
+
+    /**
+     * Retrieve and cache a secret binary from AWS Secrets Manager.
+     *
+     * @param secretId the secret ID of the desired secret.
+     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
+     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     *
+     * @return The secret binary for the desired secret.
+     */
+    public ByteBuffer getSecretBinary(final String secretId, final String versionId, final String versionStage) {
+        SecretCacheItem secret = this.getCachedSecret(secretId);
+        GetSecretValueResponse gsv = secret.getSecretValue(versionId, versionStage);
+
+        if (gsv == null) {
+            return null;
+        }
+
         return gsv.secretBinary().asByteBuffer();
     }
 

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheItem.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheItem.java
@@ -132,7 +132,7 @@ public class SecretCacheItem extends SecretCacheObject<DescribeSecretResponse> {
                 continue;
             }
 
-            if (versionId != null && entry.getKey() == versionId) {
+            if (versionId != null && versionId.equals(entry.getKey())) {
                 currentVersionId = Optional.of(versionId);
                 break;
             }
@@ -174,8 +174,8 @@ public class SecretCacheItem extends SecretCacheObject<DescribeSecretResponse> {
      * Return the cached GetSecretValue result.
      *
      * @param describeResponse the DescribeSecret result.
-     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
-     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     * @param versionId the version ID of the desired secret (optional, can be null).
+     * @param versionStage the version stage of the desired secret (optional, can be null).
      *
      * @return The cached GetSecretValue result.
      */

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheItem.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheItem.java
@@ -165,9 +165,7 @@ public class SecretCacheItem extends SecretCacheObject<DescribeSecretResponse> {
      */
     @Override
     protected GetSecretValueResponse getSecretValue(DescribeSecretResponse describeResponse) {
-        SecretCacheVersion version = getVersion(describeResponse, null, null);
-        if (null == version) { return null; }
-        return version.getSecretValue();
+        return getSecretValue(describeResponse, null, null);
     }
 
     /**

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheItem.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheItem.java
@@ -13,6 +13,8 @@
 
 package com.amazonaws.secretsmanager.caching.cache;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -115,16 +117,32 @@ public class SecretCacheItem extends SecretCacheObject<DescribeSecretResponse> {
      *            The result of the Describe Secret request to AWS Secrets Manager.
      * @return The cached secret version.
      */
-    private SecretCacheVersion getVersion(DescribeSecretResponse describeResponse) {
+    private SecretCacheVersion getVersion(DescribeSecretResponse describeResponse, String versionId, String versionStage) {
         if (null == describeResponse) { return null; }
         if (null == describeResponse.versionIdsToStages()) { return null; }
-        Optional<String> currentVersionId = describeResponse.versionIdsToStages().entrySet()
-                .stream()
-                .filter(Objects::nonNull)
-                .filter(x -> x.getValue() != null)
-                .filter(x -> x.getValue().contains(this.config.getVersionStage()))
-                .map(x -> x.getKey())
-                .findFirst();
+
+        Optional<String> currentVersionId = Optional.empty();
+
+        for (Map.Entry<String, List<String>> entry : describeResponse.versionIdsToStages().entrySet()) {
+            if (entry == null) {
+                continue;
+            }
+
+            if (entry.getValue() == null) {
+                continue;
+            }
+
+            if (versionId != null && entry.getKey() == versionId) {
+                currentVersionId = Optional.of(versionId);
+                break;
+            }
+
+            if ((versionStage != null && entry.getValue().contains(versionStage)) || entry.getValue().contains(config.getVersionStage())) {
+                currentVersionId = Optional.of(entry.getKey());
+                break;
+            }
+        }
+
         if (currentVersionId.isPresent()) {
             SecretCacheVersion version = versions.get(currentVersionId.get());
             if (null == version) {
@@ -134,6 +152,7 @@ public class SecretCacheItem extends SecretCacheObject<DescribeSecretResponse> {
             }
             return version;
         }
+
         return null;
     }
 
@@ -146,8 +165,28 @@ public class SecretCacheItem extends SecretCacheObject<DescribeSecretResponse> {
      */
     @Override
     protected GetSecretValueResponse getSecretValue(DescribeSecretResponse describeResponse) {
-        SecretCacheVersion version = getVersion(describeResponse);
+        SecretCacheVersion version = getVersion(describeResponse, null, null);
         if (null == version) { return null; }
+        return version.getSecretValue();
+    }
+
+    /**
+     * Return the cached GetSecretValue result.
+     *
+     * @param describeResponse the DescribeSecret result.
+     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
+     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     *
+     * @return The cached GetSecretValue result.
+     */
+    @Override
+    protected GetSecretValueResponse getSecretValue(DescribeSecretResponse describeResponse, String versionId, String versionStage) {
+        SecretCacheVersion version = getVersion(describeResponse, versionId, versionStage);
+
+        if (version == null) {
+            return null;
+        }
+
         return version.getSecretValue();
     }
 

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
@@ -115,8 +115,8 @@ public abstract class SecretCacheObject<T> {
      * Execute the actual refresh of the cached secret state.
      *
      * @param result the GetSecretValue or DescribeSecret result.
-     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
-     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     * @param versionId the version ID of the desired secret (optional, can be null).
+     * @param versionStage the version stage of the desired secret (optional, can be null).
      *
      * @return The cached GetSecretValue result based on the current cached state.
      */
@@ -260,8 +260,8 @@ public abstract class SecretCacheObject<T> {
     /**
      * Return the cached GetSecretValue result.
      *
-     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
-     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     * @param versionId the version ID of the desired secret (optional, can be null).
+     * @param versionStage the version stage of the desired secret (optional, can be null).
      *
      * @return The cached GetSecretValue result.
      */

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
@@ -247,14 +247,7 @@ public abstract class SecretCacheObject<T> {
      * @return The cached GetSecretValue result.
      */
     public GetSecretValueResponse getSecretValue() {
-        synchronized (lock) {
-            refresh();
-            if (null == this.data) {
-                if (null != this.exception) { throw this.exception; }
-            }
-
-            return this.getSecretValue(this.getResult());
-        }
+        return getSecretValue(null, null);
     }
 
     /**

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
@@ -111,6 +111,17 @@ public abstract class SecretCacheObject<T> {
      */
     protected abstract GetSecretValueResponse getSecretValue(T result);
 
+    /**
+     * Execute the actual refresh of the cached secret state.
+     *
+     * @param result the GetSecretValue or DescribeSecret result.
+     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
+     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     *
+     * @return The cached GetSecretValue result based on the current cached state.
+     */
+    protected abstract GetSecretValueResponse getSecretValue(T result, String versionId, String versionStage);;
+
     public abstract boolean equals(Object obj);
     public abstract int hashCode();
     public abstract String toString();
@@ -243,6 +254,28 @@ public abstract class SecretCacheObject<T> {
             }
 
             return this.getSecretValue(this.getResult());
+        }
+    }
+
+    /**
+     * Return the cached GetSecretValue result.
+     *
+     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
+     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     *
+     * @return The cached GetSecretValue result.
+     */
+    public GetSecretValueResponse getSecretValue(String versionId, String versionStage) {
+        synchronized (lock) {
+            refresh();
+
+            if (this.data == null) {
+                if (this.exception != null) {
+                    throw this.exception;
+                }
+            }
+
+            return this.getSecretValue(this.getResult(), versionId, versionStage);
         }
     }
 

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
@@ -120,7 +120,7 @@ public abstract class SecretCacheObject<T> {
      *
      * @return The cached GetSecretValue result based on the current cached state.
      */
-    protected abstract GetSecretValueResponse getSecretValue(T result, String versionId, String versionStage);;
+    protected abstract GetSecretValueResponse getSecretValue(T result, String versionId, String versionStage);
 
     public abstract boolean equals(Object obj);
     public abstract int hashCode();

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheVersion.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheVersion.java
@@ -102,8 +102,8 @@ public class SecretCacheVersion extends SecretCacheObject<GetSecretValueResponse
      * Return the cached GetSecretValue result.
      *
      * @param gsvResult the GetSecretValue or DescribeSecret result.
-     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
-     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     * @param versionId the version ID of the desired secret (optional, can be null).
+     * @param versionStage the version stage of the desired secret (optional, can be null).
      *
      * @return The cached GetSecretValue result.
      */

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheVersion.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheVersion.java
@@ -98,4 +98,18 @@ public class SecretCacheVersion extends SecretCacheObject<GetSecretValueResponse
         return gsvResult;
     }
 
+    /**
+     * Return the cached GetSecretValue result.
+     *
+     * @param gsvResult the GetSecretValue or DescribeSecret result.
+     * @param versionId the version ID of the desired secret (optional, can be <c>null</c>).
+     * @param versionStage the version stage of the desired secret (optional, can be <c>null</c>).
+     *
+     * @return The cached GetSecretValue result.
+     */
+    @Override
+    protected GetSecretValueResponse getSecretValue(GetSecretValueResponse gsvResult, String versionId, String versionStage) {
+        return gsvResult;
+    }
+
 }

--- a/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
@@ -136,6 +136,61 @@ public class SecretCacheTest {
     }
 
     @Test
+    public void basicSecretCacheVersionIdTest() {
+        final String secret = "basicSecretCacheTest";
+        Map<String, List<String>> versionMap = new HashMap<String, List<String>>();
+        versionMap.put("versionId", Arrays.asList("AWSCURRENT"));
+        versionMap.put("otherVersionId", Arrays.asList("AWSCURRENT"));
+        Mockito.when(describeSecretResponse.versionIdsToStages()).thenReturn(versionMap);
+        GetSecretValueResponse.Builder resBuilder = GetSecretValueResponse.builder().secretString(secret)
+                .secretBinary(SdkBytes.fromByteArray(secret.getBytes()));
+        getSecretValueResponse = resBuilder.build();
+
+        Mockito.when(asm.describeSecret(Mockito.any(DescribeSecretRequest.class))).thenReturn(describeSecretResponse);
+        Mockito.when(asm.getSecretValue(Mockito.any(GetSecretValueRequest.class))).thenReturn(getSecretValueResponse);
+
+        SecretCache sc = new SecretCache(asm);
+
+        // Request the secret multiple times and verify the correct result
+        repeat(10, n -> Assert.assertEquals(sc.getSecretString("", "otherVersionId", null), secret));
+
+        // Verify that multiple requests did not call the API
+        Mockito.verify(asm, Mockito.times(1)).describeSecret(Mockito.any(DescribeSecretRequest.class));
+        Mockito.verify(asm, Mockito.times(1)).getSecretValue(Mockito.any(GetSecretValueRequest.class));
+
+        repeat(10, n -> Assert.assertEquals(sc.getSecretBinary("", "otherVersionId", null),
+                ByteBuffer.wrap(secret.getBytes())));
+        sc.close();
+    }
+
+    @Test
+    public void basicSecretCacheVersionStageTest() {
+        final String secret = "basicSecretCacheTest";
+        Map<String, List<String>> versionMap = new HashMap<String, List<String>>();
+        versionMap.put("versionId", Arrays.asList("AWSCURRENT"));
+        Mockito.when(describeSecretResponse.versionIdsToStages()).thenReturn(versionMap);
+        GetSecretValueResponse.Builder resBuilder = GetSecretValueResponse.builder().secretString(secret)
+                .secretBinary(SdkBytes.fromByteArray(secret.getBytes()));
+        getSecretValueResponse = resBuilder.build();
+
+        Mockito.when(asm.describeSecret(Mockito.any(DescribeSecretRequest.class))).thenReturn(describeSecretResponse);
+        Mockito.when(asm.getSecretValue(Mockito.any(GetSecretValueRequest.class))).thenReturn(getSecretValueResponse);
+
+        SecretCache sc = new SecretCache(asm);
+
+        // Request the secret multiple times and verify the correct result
+        repeat(10, n -> Assert.assertEquals(sc.getSecretString("", null, "AWSCURRENT"), secret));
+
+        // Verify that multiple requests did not call the API
+        Mockito.verify(asm, Mockito.times(1)).describeSecret(Mockito.any(DescribeSecretRequest.class));
+        Mockito.verify(asm, Mockito.times(1)).getSecretValue(Mockito.any(GetSecretValueRequest.class));
+
+        repeat(10, n -> Assert.assertEquals(sc.getSecretBinary("", null, "AWSCURRENT"),
+                ByteBuffer.wrap(secret.getBytes())));
+        sc.close();
+    }
+
+    @Test
     public void hookSecretCacheTest() {
         final String secret = "hookSecretCacheTest";
         Map<String, List<String>> versionMap = new HashMap<String, List<String>>();


### PR DESCRIPTION
*Issue #, if available:*
#19 

*Description of changes:*
- Add optional `versionId` and `versionStage` args to `GetSecretString` and `GetSecretBinary` to allow retrieving secrets by version ID or version stage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
