### PR TITLE
fix: use OIDC for Codecov

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,28 +5,32 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "master", "v2" ]
+    branches: ["master", "v2"]
   pull_request:
-    branches: [ "master", "v2" ]
+    branches: ["master", "v2"]
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
-    - name: Set up JDK 21
-      uses: actions/setup-java@v5
-      with:
-        java-version: '21'
-        distribution: 'corretto'
-        cache: maven
-    - name: Maven version
-      run: mvn --version
-    - name: Build with Maven
-      run: mvn clean package
-    - name: Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v5
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "corretto"
+          cache: maven
+      - name: Maven version
+        run: mvn --version
+      - name: Build with Maven
+        run: mvn clean package
+      - name: Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          use_oidc: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Code coverage broke due to GitHub separating repository secrets from Dependabot secrets. Use the OIDC token to write code coverage data to Codecov.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
