### PR TITLE
Update to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.amazonaws.secretsmanager</groupId>
     <artifactId>aws-secretsmanager-caching-java</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
 
@@ -37,17 +37,14 @@
     </scm>
 
     <properties>
-        <maven.compiler.release>8</maven.compiler.release>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+            <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>secretsmanager</artifactId>
-            <version>2.29.6</version>
+            <version>2.37.1</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
@@ -58,13 +55,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.17.0</version>
+            <version>5.20.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <version>4.8.6</version>
+            <version>4.9.8</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -73,10 +70,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.14.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>8</release>
                     <compilerArgument>-Xlint:all</compilerArgument>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -98,7 +94,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.11.1</version>
+                <version>3.12.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -132,7 +128,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.8.6.5</version>
+                <version>4.9.8.1</version>
                 <configuration>
                     <effort>Max</effort>
                     <threshold>Low</threshold>
@@ -152,7 +148,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -169,26 +165,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
-                <configuration>
-                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -200,7 +176,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.7</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -214,7 +190,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/SecretCacheObject.java
@@ -14,6 +14,7 @@
 package com.amazonaws.secretsmanager.caching.cache;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -50,7 +51,7 @@ public abstract class SecretCacheObject<T> {
     protected final SecretCacheConfiguration config;
 
     /** A flag to indicate a refresh is needed. */
-    private boolean refreshNeeded = true;
+    private final AtomicBoolean refreshNeeded = new AtomicBoolean(true);
 
     /** The result of the last AWS Secrets Manager request for this item. */
     private Object data = null;
@@ -145,7 +146,9 @@ public abstract class SecretCacheObject<T> {
      * @return True if the secret item should be refreshed.
      */
     protected boolean isRefreshNeeded() {
-        if (this.refreshNeeded) { return true; }
+        if (this.refreshNeeded.get()) {
+            return true;
+        }
         if (null != this.exception) {
             // If we encountered an exception on the last attempt
             // we do not want to keep retrying without a pause between
@@ -168,7 +171,7 @@ public abstract class SecretCacheObject<T> {
      */
     private void refresh() {
         if (!this.isRefreshNeeded()) { return; }
-        this.refreshNeeded = false;
+        this.refreshNeeded.set(false);
         try {
             this.setResult(this.executeRefresh());
             this.exception = null;
@@ -204,7 +207,7 @@ public abstract class SecretCacheObject<T> {
      *             If the thread is interrupted while waiting for the refresh.
      */
     public boolean refreshNow() throws InterruptedException {
-        this.refreshNeeded = true;
+        this.refreshNeeded.set(true);
         // When forcing a refresh, always sleep with a random jitter
         // to prevent coding errors that could be calling refreshNow
         // in a loop.
@@ -235,6 +238,7 @@ public abstract class SecretCacheObject<T> {
      *
      * @return The cached GetSecretValue result.
      */
+    @SuppressFBWarnings("THROWS_METHOD_THROWS_RUNTIMEEXCEPTION")
     public GetSecretValueResponse getSecretValue() {
         synchronized (lock) {
             refresh();

--- a/src/main/java/com/amazonaws/secretsmanager/caching/cache/internal/VersionInfo.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/cache/internal/VersionInfo.java
@@ -18,17 +18,14 @@ package com.amazonaws.secretsmanager.caching.cache.internal;
  * client.
  */
 public class VersionInfo {
-    public static final String VERSION_NUM = "2";
-    // incremented for design changes that break backward compatibility.
-    public static final String MAJOR_REVISION_NUM = VERSION_NUM;
-    // incremented for minor changes to the implementation
-    public static final String MINOR_REVISION_NUM = "0";
-    // incremented for releases containing an immediate bug fix.
-    public static final String BUGFIX_REVISION_NUM = "0";
+    /**
+     * Library version number
+     */
+    public static final String RELEASE_VERSION = "2.1.0";
 
-    public static final String RELEASE_VERSION = MAJOR_REVISION_NUM + "." + MINOR_REVISION_NUM
-            + "." + BUGFIX_REVISION_NUM;
-
+    /**
+     * User agent for AWS Secrets Manager API calls.
+     */
     public static final String USER_AGENT = "AwsSecretCache/" + RELEASE_VERSION;
 
     private VersionInfo() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update dependencies
- Fix user agent to match pom.xml
- Address new SpotBugs warnings
```
Error:  Medium: Shared primitive variable "refreshNeeded" in one thread may not yield the value of the most recent write from another thread [com.amazonaws.secretsmanager.caching.cache.SecretCacheObject] At SecretCacheObject.java:[line 207] AT_STALE_THREAD_WRITE_OF_PRIMITIVE
Error:  Low: Method intentionally throws RuntimeException. [com.amazonaws.secretsmanager.caching.cache.SecretCacheObject] At SecretCacheObject.java:[line 242] THROWS_METHOD_THROWS_RUNTIMEEXCEPTION
```
- Bump version number


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
