### PR TITLE
fix: update AWS SDK to 2.40.11 to address CVE-2025-67735

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>secretsmanager</artifactId>
-            <version>2.37.1</version>
+            <version>2.40.11</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-secretsmanager-jdbc/issues/310

*Description of changes:*
Updates AWS SDK for Java v2 from 2.37.1 to 2.40.11 to address security vulnerability CVE-2025-67735 in netty dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
