### PR TITLE
Add pqtls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ public class SampleClass implements RequestHandler<String, String> {
 }
 ```
 
+### Enabling Post-Quantum TLS
+
+To enable Post-Quantum TLS for enhanced security:
+
+```java
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import com.amazonaws.secretsmanager.caching.SecretCacheConfiguration;
+
+SecretCache cache = new SecretCache(
+    new SecretCacheConfiguration()
+        .withPostQuantumTlsEnabled(true)
+);
+
+String secret = cache.getSecretString("my-secret-id");
+```
+
 ## License
 
 This library is licensed under the Apache 2.0 License. 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
             <version>2.41.3</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+            <version>2.41.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>7.11.0</version>

--- a/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
@@ -18,6 +18,7 @@ import com.amazonaws.secretsmanager.caching.cache.LRUCache;
 import com.amazonaws.secretsmanager.caching.cache.SecretCacheItem;
 import com.amazonaws.secretsmanager.caching.cache.internal.VersionInfo;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
@@ -70,6 +71,8 @@ public class SecretCache implements AutoCloseable {
      * @param builder The builder to use for creating the AWS Secrets Manager
      *                client.
      */
+    @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", 
+        justification = "Delegates to constructor that validates before field initialization")
     public SecretCache(SecretsManagerClientBuilder builder) {
         this(new SecretCacheConfiguration().withClient(builder
                 .overrideConfiguration(
@@ -85,6 +88,8 @@ public class SecretCache implements AutoCloseable {
      * @param client The AWS Secrets Manager client to use for requesting secret
      *               values.
      */
+    @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", 
+        justification = "Delegates to constructor that validates before field initialization")
     public SecretCache(SecretsManagerClient client) {
         this(new SecretCacheConfiguration().withClient(client));
     }
@@ -93,11 +98,22 @@ public class SecretCache implements AutoCloseable {
      * Constructs a new secret cache using the provided cache configuration.
      *
      * @param config The secret cache configuration.
+     * @throws IllegalArgumentException if both a custom client and postQuantumTlsEnabled 
+     *                                  are specified in the configuration.
      */
+    @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", 
+        justification = "Validation occurs before any field initialization")
     public SecretCache(SecretCacheConfiguration config) {
         if (null == config) {
             config = new SecretCacheConfiguration();
         }
+
+        if (config.getClient() != null && config.isPostQuantumTlsEnabled()) {
+            throw new IllegalArgumentException(
+                "Cannot specify both a custom client and postQuantumTlsEnabled. " +
+                "To use PQTLS, omit the custom client or configure your client with PQTLS support.");
+        }
+
         this.cache = new LRUCache<String, SecretCacheItem>(config.getMaxCacheSize());
         this.config = config;
         ClientOverrideConfiguration defaultOverride = ClientOverrideConfiguration.builder()

--- a/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
@@ -121,17 +121,16 @@ public class SecretCache implements AutoCloseable {
 
         if (config.getClient() != null) {
             this.client = config.getClient();
-        } else if (config.isPostQuantumTlsEnabled()) {
-            this.client = SecretsManagerClient.builder()
-                .httpClient(AwsCrtHttpClient.builder()
-                .postQuantumTlsEnabled(true)
-                .build())
-            .overrideConfiguration(defaultOverride)
-            .build();
         } else {
-            this.client = SecretsManagerClient.builder()
-                .overrideConfiguration(defaultOverride)
-                .build();
+            SecretsManagerClientBuilder builder = SecretsManagerClient.builder();
+            
+            if (config.isPostQuantumTlsEnabled()) {
+                builder.httpClient(AwsCrtHttpClient.builder()
+                    .postQuantumTlsEnabled(true)
+                    .build());
+            }
+        
+            this.client = builder.overrideConfiguration(defaultOverride).build();
         }
     }
 

--- a/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/SecretCache.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 
 /**
  * Provides the primary entry-point to the AWS Secrets Manager client cache SDK.
@@ -101,8 +102,21 @@ public class SecretCache implements AutoCloseable {
         this.config = config;
         ClientOverrideConfiguration defaultOverride = ClientOverrideConfiguration.builder()
                 .putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX, VersionInfo.USER_AGENT).build();
-        this.client = config.getClient() != null ? config.getClient()
-                : SecretsManagerClient.builder().overrideConfiguration(defaultOverride).build();
+
+        if (config.getClient() != null) {
+            this.client = config.getClient();
+        } else if (config.isPostQuantumTlsEnabled()) {
+            this.client = SecretsManagerClient.builder()
+                .httpClient(AwsCrtHttpClient.builder()
+                .postQuantumTlsEnabled(true)
+                .build())
+            .overrideConfiguration(defaultOverride)
+            .build();
+        } else {
+            this.client = SecretsManagerClient.builder()
+                .overrideConfiguration(defaultOverride)
+                .build();
+        }
     }
 
     /**

--- a/src/main/java/com/amazonaws/secretsmanager/caching/SecretCacheConfiguration.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/SecretCacheConfiguration.java
@@ -307,6 +307,10 @@ public class SecretCacheConfiguration {
     /**
      * Sets whether to enable Post-Quantum TLS.
      *
+     * <p>Note: This setting is mutually exclusive with providing a custom client via 
+     * {@link #withClient(SecretsManagerClient)}. If both are specified, an 
+     * {@link IllegalArgumentException} will be thrown.
+     * 
      * @param postQuantumTlsEnabled
      *            Whether to enable Post-Quantum TLS.
      */
@@ -316,7 +320,11 @@ public class SecretCacheConfiguration {
 
     /**
      * Sets whether to enable Post-Quantum TLS.
-     *
+     * 
+     * <p>Note: This setting is mutually exclusive with providing a custom client via 
+     * {@link #withClient(SecretsManagerClient)}. If both are specified, an 
+     * {@link IllegalArgumentException} will be thrown.
+     * 
      * @param postQuantumTlsEnabled
      *            Whether to enable Post-Quantum TLS.
      * @return The updated SecretCacheConfiguration object with the new PQTLS setting.

--- a/src/main/java/com/amazonaws/secretsmanager/caching/SecretCacheConfiguration.java
+++ b/src/main/java/com/amazonaws/secretsmanager/caching/SecretCacheConfiguration.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
-
 /**
  * Cache configuration options such as max cache size, ttl for cached items, etc.
  *
@@ -72,6 +71,11 @@ public class SecretCacheConfiguration {
      * executing a refreshNow in a continuous loop without waiting.
      */
     private long forceRefreshJitterMillis = DEFAULT_FORCE_REFRESH_JITTER;
+
+    /** 
+     * Whether to enable Post-Quantum TLS. 
+     * */
+    private boolean postQuantumTlsEnabled = false;
 
     /**
      * Default constructor for the SecretCacheConfiguration object.
@@ -291,4 +295,34 @@ public class SecretCacheConfiguration {
         return this;
     }
 
+    /**
+     * Returns whether Post-Quantum TLS is enabled.
+     *
+     * @return true if Post-Quantum TLS is enabled, false otherwise.
+     */
+    public boolean isPostQuantumTlsEnabled() {
+        return this.postQuantumTlsEnabled;
+    }
+
+    /**
+     * Sets whether to enable Post-Quantum TLS.
+     *
+     * @param postQuantumTlsEnabled
+     *            Whether to enable Post-Quantum TLS.
+     */
+    public void setPostQuantumTlsEnabled(boolean postQuantumTlsEnabled) {
+        this.postQuantumTlsEnabled = postQuantumTlsEnabled;
+    }
+
+    /**
+     * Sets whether to enable Post-Quantum TLS.
+     *
+     * @param postQuantumTlsEnabled
+     *            Whether to enable Post-Quantum TLS.
+     * @return The updated SecretCacheConfiguration object with the new PQTLS setting.
+     */
+    public SecretCacheConfiguration withPostQuantumTlsEnabled(boolean postQuantumTlsEnabled) {
+        this.setPostQuantumTlsEnabled(postQuantumTlsEnabled);
+        return this;
+    }
 }

--- a/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
@@ -482,4 +482,30 @@ public class SecretCacheTest {
         sc.close();
     }
 
+    @Test
+    public void testPostQuantumTlsConfiguration() {
+        // Test default is false
+        SecretCacheConfiguration config = new SecretCacheConfiguration();
+        Assert.assertFalse(config.isPostQuantumTlsEnabled());
+        
+        // Test setter
+        config.setPostQuantumTlsEnabled(true);
+        Assert.assertTrue(config.isPostQuantumTlsEnabled());
+        
+        // Test fluent method
+        SecretCacheConfiguration config2 = new SecretCacheConfiguration()
+            .withPostQuantumTlsEnabled(true);
+        Assert.assertTrue(config2.isPostQuantumTlsEnabled());
+    }
+
+    @Test
+    public void testSecretCacheWithPQTLSEnabled() {
+        // Verify cache can be created with PQTLS enabled without errors
+        SecretCacheConfiguration config = new SecretCacheConfiguration()
+            .withPostQuantumTlsEnabled(true);
+        
+        SecretCache cache = new SecretCache(config);
+        Assert.assertNotNull(cache);
+        cache.close();
+    }
 }

--- a/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
@@ -498,16 +498,14 @@ public class SecretCacheTest {
         Assert.assertTrue(config2.isPostQuantumTlsEnabled());
     }
 
-    @Test
+    @Test(expectedExceptions = { IllegalArgumentException.class })
     public void testSecretCacheWithPQTLSEnabled() {
-        // Verify cache can be created with PQTLS enabled without errors
+        // Verify that providing both client and PQTLS flag throws exception
         SecretCacheConfiguration config = new SecretCacheConfiguration()
             .withClient(asm) 
             .withPostQuantumTlsEnabled(true);
         
-        SecretCache cache = new SecretCache(config);
-        Assert.assertNotNull(cache);
-        cache.close();
+        new SecretCache(config);  
     }
 
     @Test

--- a/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
@@ -509,4 +509,23 @@ public class SecretCacheTest {
         Assert.assertNotNull(cache);
         cache.close();
     }
+
+    @Test
+    public void testSecretCacheWithPQTLSEnabledNoClient() {
+        String originalRegion = System.getProperty("aws.region");
+        try {
+            System.setProperty("aws.region", "us-east-1");
+            SecretCacheConfiguration config = new SecretCacheConfiguration()
+                .withPostQuantumTlsEnabled(true);  // No .withClient() call
+            SecretCache cache = new SecretCache(config);
+            Assert.assertNotNull(cache);
+            cache.close();
+        } finally {
+            if (originalRegion != null) {
+                System.setProperty("aws.region", originalRegion);
+            } else {
+                System.clearProperty("aws.region");
+            }
+        }
+    }
 }

--- a/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
+++ b/src/test/java/com/amazonaws/secretsmanager/caching/SecretCacheTest.java
@@ -502,6 +502,7 @@ public class SecretCacheTest {
     public void testSecretCacheWithPQTLSEnabled() {
         // Verify cache can be created with PQTLS enabled without errors
         SecretCacheConfiguration config = new SecretCacheConfiguration()
+            .withClient(asm) 
             .withPostQuantumTlsEnabled(true);
         
         SecretCache cache = new SecretCache(config);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add Post-Quantum TLS support to AWS Secrets Manager Java caching client. Adds configuration option `withPostQuantumTlsEnabled()` that uses AWS CRT HTTP client with PQTLS enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
