### PR TITLE
Add PQ-TLS macOS/Windows compatibility note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ SecretCache cache = new SecretCache(
 String secret = cache.getSecretString("my-secret-id");
 ```
 
+**NOTE**: PQ-TLS uses the AWS Common Runtime (CRT) which relies on system libraries and may not work as expected on macOS or Windows at this time ([ref](https://github.com/awslabs/aws-crt-java#tls-behavior)).
+
 ## License
 
 This library is licensed under the Apache 2.0 License. 


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Users attempting to use PQ-TLS on macOS or Windows may encounter unexpected behavior due to AWS CRT system library dependencies. This note proactively informs users of the known limitation.


### What is changing?

1. 1. Added a note in the "Enabling Post-Quantum TLS" section of the README warning that PQ-TLS may not work as expected on macOS or Windows due to AWS CRT system library dependencies, with a reference link.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. Documentation-only change

### When testing locally, provide testing artifact(s):

1. Verified README renders correctly using VS Code Markdown preview.

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [ ] Build and Unit tests are passing
  *If not, why:*
- [ ] Unit test coverage check is passing
  *If not, why:*
- [ ] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
